### PR TITLE
GStreamer plugins split into separate binaries

### DIFF
--- a/gst/parser/SubtitleParser.h
+++ b/gst/parser/SubtitleParser.h
@@ -1,6 +1,6 @@
-#include <gst/gst.h>
-#include <SubtitlesParserFactory.h>
 #include "SubtitleParserUtils.h"
+
+#include <gst/gst.h>
 #include <gst/subtitle/subtitle.h>
 
 namespace SubtitleParser

--- a/gst/parser/SubtitleParserUtils.h
+++ b/gst/parser/SubtitleParserUtils.h
@@ -1,5 +1,6 @@
-#include <gst/gst.h>
 #include <SubtitlesParserFactory.h>
+
+#include <gst/gst.h>
 #include <gst/subtitle/subtitle.h>
 
 GST_DEBUG_CATEGORY_STATIC(ttmlparse);

--- a/libs/gst/subtitle/TimedTextCWrapper.h
+++ b/libs/gst/subtitle/TimedTextCWrapper.h
@@ -6,6 +6,16 @@
 
 #include <stdint.h>
 
+#if defined(gstttmlcommon_EXPORTS)
+#if defined(WIN32)
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT __attribute__ ((visibility ("default")))
+#endif
+#else
+#define DLLEXPORT
+#endif
+
 typedef struct CLengthExpression CLengthExpression;
 typedef struct CLengthExpression CFontSize; //horizontal font size
 typedef struct TextDecoration CTextDecoration;
@@ -21,17 +31,17 @@ typedef enum { pixel, em, cell, percentage } CLengthUnit;
 typedef enum { Horizontal, Vertical } COrientation;
 
 //CLengthExpression interface
-CLengthExpression* create_length_expression(double, CLengthUnit, COrientation);
-CLengthExpression* create_length_expression_from_value(double);
-void free_length_expression(CLengthExpression*);
-uint32_t to_pixel(CLengthExpression*, uint32_t, uint32_t);
+DLLEXPORT CLengthExpression* create_length_expression(double, CLengthUnit, COrientation);
+DLLEXPORT CLengthExpression* create_length_expression_from_value(double);
+DLLEXPORT void free_length_expression(CLengthExpression*);
+DLLEXPORT uint32_t to_pixel(CLengthExpression*, uint32_t, uint32_t);
 
 //-------------------------------------------------------------------
 //TextOutline interface
-void create_text_outline_default(CTextOutline*);
-bool is_text_outline_default(CTextOutline);
-bool is_text_outline_equal(CTextOutline, CTextOutline);
-void free_text_outline(CTextOutline);
+DLLEXPORT void create_text_outline_default(CTextOutline*);
+DLLEXPORT bool is_text_outline_default(CTextOutline);
+DLLEXPORT bool is_text_outline_equal(CTextOutline, CTextOutline);
+DLLEXPORT void free_text_outline(CTextOutline);
 
 //-------------------------------------------------------------------
 struct TextDecoration {

--- a/libs/gst/subtitle/gstsubtitle.h
+++ b/libs/gst/subtitle/gstsubtitle.h
@@ -394,7 +394,7 @@ struct _GstSubtitleStyleSet {
   CTextOutline text_outline;
 };
 
-GstSubtitleStyleSet * gst_subtitle_style_set_new ();
+DLLEXPORT GstSubtitleStyleSet * gst_subtitle_style_set_new ();
 
 void gst_subtitle_style_set_free (GstSubtitleStyleSet * style_set);
 
@@ -429,8 +429,7 @@ struct _GstSubtitleElement
 
 GType gst_subtitle_element_get_type (void);
 
-GstSubtitleElement * gst_subtitle_element_new (GstSubtitleStyleSet * style_set,
-    guint text_index, gboolean suppress_whitespace);
+DLLEXPORT GstSubtitleElement * gst_subtitle_element_new (GstSubtitleStyleSet * style_set, guint text_index, gboolean suppress_whitespace);
 
 /**
  * gst_subtitle_element_ref:
@@ -485,16 +484,13 @@ struct _GstSubtitleBlock
 
 GType gst_subtitle_block_get_type (void);
 
-GstSubtitleBlock * gst_subtitle_block_new (GstSubtitleStyleSet * style_set);
+DLLEXPORT GstSubtitleBlock * gst_subtitle_block_new (GstSubtitleStyleSet * style_set);
 
-void gst_subtitle_block_add_element (
-    GstSubtitleBlock * block,
-    GstSubtitleElement * element);
+DLLEXPORT void gst_subtitle_block_add_element (GstSubtitleBlock * block, GstSubtitleElement * element);
 
-guint gst_subtitle_block_get_element_count (const GstSubtitleBlock * block);
+DLLEXPORT guint gst_subtitle_block_get_element_count (const GstSubtitleBlock * block);
 
-const GstSubtitleElement * gst_subtitle_block_get_element (
-    const GstSubtitleBlock * block, guint index);
+DLLEXPORT const GstSubtitleElement * gst_subtitle_block_get_element (const GstSubtitleBlock * block, guint index);
 
 /**
  * gst_subtitle_block_ref:
@@ -552,16 +548,13 @@ struct _GstSubtitleRegion
 
 GType gst_subtitle_region_get_type (void);
 
-GstSubtitleRegion * gst_subtitle_region_new (GstSubtitleStyleSet * style_set);
+DLLEXPORT GstSubtitleRegion * gst_subtitle_region_new (GstSubtitleStyleSet * style_set);
 
-void gst_subtitle_region_add_block (
-    GstSubtitleRegion * region,
-    GstSubtitleBlock * block);
+DLLEXPORT void gst_subtitle_region_add_block (GstSubtitleRegion * region, GstSubtitleBlock * block);
 
-guint gst_subtitle_region_get_block_count (const GstSubtitleRegion * region);
+DLLEXPORT guint gst_subtitle_region_get_block_count (const GstSubtitleRegion * region);
 
-const GstSubtitleBlock * gst_subtitle_region_get_block (
-    const GstSubtitleRegion * region, guint index);
+DLLEXPORT const GstSubtitleBlock * gst_subtitle_region_get_block (const GstSubtitleRegion * region, guint index);
 
 /**
  * gst_subtitle_region_ref:

--- a/libs/gst/subtitle/gstsubtitlemeta.c
+++ b/libs/gst/subtitle/gstsubtitlemeta.c
@@ -62,7 +62,7 @@ gst_subtitle_meta_free (GstMeta * meta, GstBuffer * buffer)
 const GstMetaInfo *
 gst_subtitle_meta_get_info (void)
 {
-  static const GstMetaInfo *subtitle_meta_info = NULL;
+  static GstMetaInfo *subtitle_meta_info = NULL;
 
   if (g_once_init_enter (&subtitle_meta_info)) {
     const GstMetaInfo *meta =

--- a/libs/gst/subtitle/gstsubtitlemeta.h
+++ b/libs/gst/subtitle/gstsubtitlemeta.h
@@ -43,7 +43,7 @@ struct _GstSubtitleMeta {
   GPtrArray *regions;
 };
 
-GType gst_subtitle_meta_api_get_type (void);
+DLLEXPORT GType gst_subtitle_meta_api_get_type (void);
 #define GST_SUBTITLE_META_API_TYPE (gst_subtitle_meta_api_get_type())
 
 #define gst_buffer_get_subtitle_meta(b) \
@@ -56,7 +56,7 @@ gboolean gst_subtitle_meta_init (GstMeta * meta, gpointer params,
 
 void gst_subtitle_meta_free (GstMeta * meta, GstBuffer * buffer);
 
-const GstMetaInfo * gst_subtitle_meta_get_info (void);
+DLLEXPORT const GstMetaInfo * gst_subtitle_meta_get_info (void);
 
 GstSubtitleMeta * gst_buffer_add_subtitle_meta (GstBuffer * buffer,
     GPtrArray * regions);


### PR DESCRIPTION
A part of https://github.com/castlabs/gstreamer_asl/pull/23 update

I am adding these commits to your branch in order to step off from our worker builds with `TEMPORARY_STATIC_PLUGIN` = `ON` and have GStreamer plugins separated into different binaries, as GStreamer expects.

Please review if we can move on from there and then, in particular, this opens two new questions:

1. even though I split shared helpers of ttml parser and renderer into ttmlcommon.dll, which is required so that renderer recognizes parser buffers, the strings are effectively displayed incorrectly, maybe you can look into this while I am reviewing further
2. we obviously have now BBC code in two separate DLLs already, decoupled from main ASL source plugin; next step would be to shave off our subtitles library from static into shared, so that we open source original TTML code under LGPL without need to disclose `subtitles` - I will look into this further with the review

We will also have to clean things up in CMake as I copy/pasted a bit too much.