### PR TITLE
GST-57 WebVTT subtitles

### DIFF
--- a/gst/parser/SubtitleParser.cpp
+++ b/gst/parser/SubtitleParser.cpp
@@ -1,13 +1,22 @@
 #include "SubtitleParser.h"
 using namespace SubtitleParser;
 
-clc_Result Parser::Parse(const clc::String& doc, timedText::SubtitlesFormat format, bool forcedOnly)
+clc_Result Parser::Parse(const clc::String& doc, bool forcedOnly)
 {
-	auto parser = timedText::SubtitlesParserFactory::createParser(format, this->pool);
-
-	auto ret = parser->parse(doc, defaultTrackId);
-	if(ret != CLC_SUCCESS)
+	//naive guess format
+	clc::Result ret = CLC_NOT_INITIALIZED;
+	for(const auto format : supportedSubtitlesTypes) {
+		auto parser = timedText::SubtitlesParserFactory::createParser(format, this->pool);
+		ret = parser->parse(doc, defaultTrackId);
+		if(ret == CLC_SUCCESS) { 
+			break; 
+		}
+		pool.restart();
+	}
+	
+	if(ret != CLC_SUCCESS) {
 		return CLC_FAIL;
+	}
 
 	this->pool.setCurrentTrackIndex(defaultTrackId);
 	this->sceneHandler = std::make_unique<SubtitleParserUtils::SceneHandler>(pool);

--- a/gst/parser/SubtitleParser.h
+++ b/gst/parser/SubtitleParser.h
@@ -5,12 +5,14 @@
 
 namespace SubtitleParser
 {
+	using timedText::SubtitlesFormat;
 	static const size_t defaultTrackId = 0;
+	static const std::vector<SubtitlesFormat> supportedSubtitlesTypes = { SubtitlesFormat::WebVTT , SubtitlesFormat::TTML };
 
 	class Parser
 	{
 	public:		
-		clc_Result Parse(const clc::String& doc, timedText::SubtitlesFormat format, bool forcedOnly = false);
+		clc_Result Parse(const clc::String& doc, bool forcedOnly = false);
 
 		std::vector<GstBuffer*> getSubtitles() { return sceneHandler->getSceneBuffers(); }
 

--- a/gst/parser/SubtitleParserCWrapper.cpp
+++ b/gst/parser/SubtitleParserCWrapper.cpp
@@ -3,9 +3,10 @@
 
 extern "C"
 {
-	CParser* parse_ttml(char* doc, bool forced_only) {
+	CParser* parse_ttml(char* doc, CSubtitlesFormat c_format, bool forced_only) {
 		SubtitleParser::Parser* ttmlParser = new SubtitleParser::Parser();
-		if (ttmlParser->Parse(doc, timedText::SubtitlesFormat::TTML, forced_only) == CLC_FAIL) {
+		auto format = static_cast<timedText::SubtitlesFormat>(c_format);
+		if (ttmlParser->Parse(doc, format, forced_only) == CLC_FAIL) {
 			return NULL;
 		}
 		return reinterpret_cast<CParser*>(ttmlParser);

--- a/gst/parser/SubtitleParserCWrapper.cpp
+++ b/gst/parser/SubtitleParserCWrapper.cpp
@@ -3,10 +3,9 @@
 
 extern "C"
 {
-	CParser* parse_ttml(char* doc, CSubtitlesFormat c_format, bool forced_only) {
+	CParser* parse_ttml(char* doc, bool forced_only) {
 		SubtitleParser::Parser* ttmlParser = new SubtitleParser::Parser();
-		auto format = static_cast<timedText::SubtitlesFormat>(c_format);
-		if (ttmlParser->Parse(doc, format, forced_only) == CLC_FAIL) {
+		if (ttmlParser->Parse(doc, forced_only) == CLC_FAIL) {
 			return NULL;
 		}
 		return reinterpret_cast<CParser*>(ttmlParser);

--- a/gst/parser/SubtitleParserCWrapper.h
+++ b/gst/parser/SubtitleParserCWrapper.h
@@ -13,9 +13,8 @@ extern "C" {
 #endif
 
 typedef struct CParser CParser;
-typedef enum CSubtitlesFormat { TTML, WebVTT } CSubtitlesFormat;
 
-CParser* parse_ttml(char*, CSubtitlesFormat, bool);
+CParser* parse_ttml(char*, bool);
 
 GList* get_subtitles(CParser*);
 

--- a/gst/parser/SubtitleParserCWrapper.h
+++ b/gst/parser/SubtitleParserCWrapper.h
@@ -13,8 +13,9 @@ extern "C" {
 #endif
 
 typedef struct CParser CParser;
+typedef enum CSubtitlesFormat { TTML, WebVTT } CSubtitlesFormat;
 
-CParser* parse_ttml(char*, bool);
+CParser* parse_ttml(char*, CSubtitlesFormat, bool);
 
 GList* get_subtitles(CParser*);
 

--- a/gst/parser/gstttmlparse.c
+++ b/gst/parser/gstttmlparse.c
@@ -1607,8 +1607,7 @@ handle_buffer (GstTtmlParse * self, GstBuffer * buf)
   if (g_strcmp0 (self->subtitle_codec, "EBUTT") == 0) {
     GList *subtitle;
     GTimer *timer = g_timer_new ();
-    CSubtitlesFormat format = WebVTT;//TTML;
-    CParser *ttml_parser = parse_ttml (self->textbuf->str, format, self->forced_only);
+    CParser *ttml_parser = parse_ttml (self->textbuf->str, self->forced_only);
     if (ttml_parser == NULL) {
       GstEvent *event = gst_event_new_gap (GST_BUFFER_PTS (buf), GST_BUFFER_DURATION (buf));
       gst_pad_push_event (self->srcpad, event);

--- a/gst/parser/gstttmlparse.c
+++ b/gst/parser/gstttmlparse.c
@@ -1607,8 +1607,8 @@ handle_buffer (GstTtmlParse * self, GstBuffer * buf)
   if (g_strcmp0 (self->subtitle_codec, "EBUTT") == 0) {
     GList *subtitle;
     GTimer *timer = g_timer_new ();
-
-    CParser *ttml_parser = parse_ttml (self->textbuf->str, self->forced_only);
+    CSubtitlesFormat format = WebVTT;//TTML;
+    CParser *ttml_parser = parse_ttml (self->textbuf->str, format, self->forced_only);
     if (ttml_parser == NULL) {
       GstEvent *event = gst_event_new_gap (GST_BUFFER_PTS (buf), GST_BUFFER_DURATION (buf));
       gst_pad_push_event (self->srcpad, event);


### PR DESCRIPTION
Add support of WebVTT subtitles by guessing format.

Note: it was the fastest and easiest way to add WebVTT support (considering BBC initially also uses guessing format for various subtitle types), open to discussion.