### PR TITLE
GST-100: WebVTT signaling

### DIFF
--- a/gst/parser/gstttmlparse.c
+++ b/gst/parser/gstttmlparse.c
@@ -97,7 +97,7 @@ static GstStaticPadTemplate sink_templ = GST_STATIC_PAD_TEMPLATE ("sink",
 static GstStaticPadTemplate sink_templ = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS ("application/ttml+xml")
+    GST_STATIC_CAPS ("application/x-subtitle-vtt; application/ttml+xml")
     );
 
 


### PR DESCRIPTION
This adds the WebVTT MIME type to the static caps of `ttmlparse`, the absolute minimum to support true WebVTT signaling as it is done in GStreamer. The implementation should be expanded to support type finding and autodetect (as in `subparse`) at some point (for now this will be treated same as TTML, which happens to work with the implementation the way it is implemented currently).

This allows use to do proper format signaling from `claslsrc` for WebVTT, which means we can used it with `subparse`/`subtitleoverlay` as well as out own subtitle components. 