### PR TITLE
GST-124 Use of signed pixels

### DIFF
--- a/libs/gst/subtitle/TimedTextCWrapper.cpp
+++ b/libs/gst/subtitle/TimedTextCWrapper.cpp
@@ -19,7 +19,7 @@ extern "C"
 		delete original_len_expr;
 	}
 
-	uint32_t to_pixel(CLengthExpression* len_expr, uint32_t width, uint32_t height) {
+	int32_t to_pixel(CLengthExpression* len_expr, int32_t width, int32_t height) {
 		timedText::LengthExpression* original_len_expr = reinterpret_cast<timedText::LengthExpression*>(len_expr);
 		return original_len_expr->toPixel(timedText::Point<timedText::Px>{ width, height });
 	}

--- a/libs/gst/subtitle/TimedTextCWrapper.h
+++ b/libs/gst/subtitle/TimedTextCWrapper.h
@@ -34,7 +34,7 @@ typedef enum { Horizontal, Vertical } COrientation;
 DLLEXPORT CLengthExpression* create_length_expression(double, CLengthUnit, COrientation);
 DLLEXPORT CLengthExpression* create_length_expression_from_value(double);
 DLLEXPORT void free_length_expression(CLengthExpression*);
-DLLEXPORT uint32_t to_pixel(CLengthExpression*, uint32_t, uint32_t);
+DLLEXPORT int32_t to_pixel(CLengthExpression*, int32_t, int32_t);
 
 //-------------------------------------------------------------------
 //TextOutline interface


### PR DESCRIPTION
Caused by https://github.com/castlabs/common_libs_timed-text/pull/182 (and is actually fixed by previous @khwaaj commit I did not pull before fixing myself)

My quick look left me an impression that this repo assumed unsigned pixels and casts are generally unsafe, at least some of them. It's probably of low priority, but this might need a review some time later.

For now maybe let's just make wrapper look aligned with our repo, so that this problem could be revealed by verbose warnings on this repo build.