### PR TITLE
GST-133 Add rudimentary support for attaching composition metadata

### DIFF
--- a/gst/renderer/gstttmlrender.h
+++ b/gst/renderer/gstttmlrender.h
@@ -107,6 +107,7 @@ struct _GstTtmlRender {
 
     gboolean                 need_render;
 
+    gboolean                 attach_compo_to_buffer;
     GList * compositions;
 };
 


### PR DESCRIPTION
Early stage experiment to allow attaching metadata compositions as metadata to buffers, instead of always blending the compositions on top of the video.
_Note: improved, see comments bellow._