### PR TITLE
CPD-91: Use forced resolution for overlay composition when requested by downstream peer

### DIFF
--- a/gst/renderer/gstttmlrender.c
+++ b/gst/renderer/gstttmlrender.c
@@ -346,7 +346,7 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
 
   /* Try to use the render meta if possible */
   f = gst_caps_get_features (caps, 0);
-  GST_DEBUG ("Caps features %p, contains overlay composition %d", f, gst_caps_features_contains (f, GST_CAPS_FEATURE_META_GST_VIDEO_OVERLAY_COMPOSITION));
+  GST_DEBUG ("Caps features %" GST_PTR_FORMAT ", contains overlay composition %d", f, gst_caps_features_contains (f, GST_CAPS_FEATURE_META_GST_VIDEO_OVERLAY_COMPOSITION));
 
   /* if the caps doesn't have the render meta, we query if downstream
    * accepts it before trying the version without the meta
@@ -2249,6 +2249,8 @@ gst_ttml_render_render_text_region (GstTtmlRender * render,
 
   GST_CAT_DEBUG (ttmlrender, "Height of rendered region: %u",
       region_image->height);
+
+  GST_INFO ("Overlay is %d x %d over video %d x %d", region_image->width, region_image->height, render->width, render->height);
 
   gst_ttml_render_compose_overlay (render, region_image);
   gst_ttml_render_rendered_image_free (region_image);

--- a/gst/renderer/gstttmlrender.c
+++ b/gst/renderer/gstttmlrender.c
@@ -329,7 +329,7 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
   gboolean original_has_meta = FALSE;
   gboolean allocation_ret = TRUE;
 
-  GST_DEBUG_OBJECT (render, ">>> performing negotiation");
+  GST_DEBUG_OBJECT (render, "performing negotiation");
 
   /* Clear any pending reconfigure to avoid negotiating twice */
   gst_pad_check_reconfigure (render->srcpad);
@@ -343,6 +343,14 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
     goto no_format;
 
   original_caps = caps;
+
+  GstStructure const* const structure = gst_caps_get_structure (caps, 0);
+  gint overlay_composition_width, overlay_composition_height;
+  if (gst_structure_get_int (structure, "overlay-composition-width", &overlay_composition_width) && gst_structure_get_int (structure, "overlay-composition-height", &overlay_composition_height)) {
+    if (overlay_composition_width > 0 && overlay_composition_height > 0) {
+      GST_DEBUG ("Applying downstream preference for overlay composition resolution %d x %d", overlay_composition_width, overlay_composition_height);
+    }
+  }
 
   /* Try to use the render meta if possible */
   f = gst_caps_get_features (caps, 0);
@@ -380,7 +388,7 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
   } else {
     original_has_meta = TRUE;
   }
-  GST_DEBUG_OBJECT (render, ">>> Using caps %" GST_PTR_FORMAT ", original_has_meta %d, caps_has_meta %d", caps, original_has_meta, caps_has_meta);
+  GST_DEBUG_OBJECT (render, "Using caps %" GST_PTR_FORMAT ", original_has_meta %d, caps_has_meta %d", caps, original_has_meta, caps_has_meta);
   ret = gst_pad_set_caps (render->srcpad, caps);
 
   if (ret) {
@@ -418,6 +426,8 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
   }
 
   render->attach_compo_to_buffer = attach;
+  render->overlay_composition_width = overlay_composition_width;
+  render->overlay_composition_height = overlay_composition_height;
 
   if (!ret) {
     GST_DEBUG_OBJECT (render, "negotiation failed, schedule reconfigure");
@@ -472,6 +482,12 @@ gst_ttml_render_setcaps (GstTtmlRender * render, GstCaps * caps)
       !gst_ttml_render_can_handle_caps (caps)) {
     GST_DEBUG_OBJECT (render, "unsupported caps %" GST_PTR_FORMAT, caps);
     ret = FALSE;
+  }
+  if (ret && render->attach_compo_to_buffer) {
+    if (render->overlay_composition_width > 0 && render->overlay_composition_height > 0) {
+      render->width = render->overlay_composition_width;
+      render->height = render->overlay_composition_height;
+    }
   }
 
   g_mutex_unlock (GST_TTML_RENDER_GET_CLASS (render)->pango_lock);
@@ -932,6 +948,18 @@ gst_ttml_render_text_event (GstPad * pad, GstObject * parent,
   return ret;
 }
 
+static void 
+gst_ttml_render_overlay_composition_caps (GstTtmlRender* render, gint* width, gint* height) {
+  g_assert (render);
+  g_assert (width && height);
+  *width = render->width;
+  *height = render->height;
+  if (render->attach_compo_to_buffer && render->overlay_composition_width > 0 && render->overlay_composition_height > 0) {
+    *width = render->overlay_composition_width;
+    *height = render->overlay_composition_height;
+  }
+}
+
 static gboolean
 gst_ttml_render_video_event (GstPad * pad, GstObject * parent,
     GstEvent * event)
@@ -947,14 +975,17 @@ gst_ttml_render_video_event (GstPad * pad, GstObject * parent,
     case GST_EVENT_CAPS:
     {
       GstCaps *caps;
-      gint prev_width = render->width;
-      gint prev_height = render->height;
-
       gst_event_parse_caps (event, &caps);
+      gint current_width, current_height;
+      gst_ttml_render_overlay_composition_caps (render, &current_width, &current_height);
       ret = gst_ttml_render_setcaps (render, caps);
-      if (render->width != prev_width || render->height != prev_height) {
-        GST_DEBUG ("Render resolution changed from %d x %d to %d x %d", prev_width, prev_height, render->width, render->height);
-        render->need_render = TRUE;
+      if (ret) {
+        gint width, height;
+        gst_ttml_render_overlay_composition_caps (render, &width, &height);
+        if (width != current_width || height != current_height) {
+          GST_DEBUG ("Render resolution changed from %d x %d to %d x %d", current_width, current_height, width, height);
+          render->need_render = TRUE;
+        }
       }
       gst_event_unref (event);
       break;

--- a/gst/renderer/gstttmlrender.c
+++ b/gst/renderer/gstttmlrender.c
@@ -390,7 +390,8 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
   } else {
     original_has_meta = TRUE;
   }
-  GST_DEBUG_OBJECT (render, "Using caps %" GST_PTR_FORMAT ", original_has_meta %d, caps_has_meta %d", caps, original_has_meta, caps_has_meta);
+  GST_DEBUG_OBJECT (render, "Using caps %" GST_PTR_FORMAT ", original_has_meta %d, caps_has_meta %d",
+    caps, original_has_meta, caps_has_meta);
   ret = gst_pad_set_caps (render->srcpad, caps);
 
   if (ret) {

--- a/gst/renderer/gstttmlrender.c
+++ b/gst/renderer/gstttmlrender.c
@@ -60,7 +60,8 @@
 GST_DEBUG_CATEGORY_EXTERN (ttmlrender);
 #define GST_CAT_DEFAULT ttmlrender
 
-#define VIDEO_FORMATS GST_VIDEO_OVERLAY_COMPOSITION_BLEND_FORMATS
+// WARN: Force NV12 in order to eliminate downstream format conversion to NV12 compatible with kmssink
+#define VIDEO_FORMATS "{ NV12 }" // GST_VIDEO_OVERLAY_COMPOSITION_BLEND_FORMATS
 
 #define TTML_RENDER_CAPS GST_VIDEO_CAPS_MAKE (VIDEO_FORMATS)
 

--- a/gst/renderer/gstttmlrender.c
+++ b/gst/renderer/gstttmlrender.c
@@ -60,8 +60,7 @@
 GST_DEBUG_CATEGORY_EXTERN (ttmlrender);
 #define GST_CAT_DEFAULT ttmlrender
 
-// WARN: Force NV12 in order to eliminate downstream format conversion to NV12 compatible with kmssink
-#define VIDEO_FORMATS "{ NV12 }" // GST_VIDEO_OVERLAY_COMPOSITION_BLEND_FORMATS
+#define VIDEO_FORMATS GST_VIDEO_OVERLAY_COMPOSITION_BLEND_FORMATS
 
 #define TTML_RENDER_CAPS GST_VIDEO_CAPS_MAKE (VIDEO_FORMATS)
 

--- a/gst/renderer/gstttmlrender.c
+++ b/gst/renderer/gstttmlrender.c
@@ -328,7 +328,7 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
   gboolean original_has_meta = FALSE;
   gboolean allocation_ret = TRUE;
 
-  GST_DEBUG_OBJECT (render, "performing negotiation");
+  GST_DEBUG_OBJECT (render, ">>> performing negotiation");
 
   /* Clear any pending reconfigure to avoid negotiating twice */
   gst_pad_check_reconfigure (render->srcpad);
@@ -345,6 +345,7 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
 
   /* Try to use the render meta if possible */
   f = gst_caps_get_features (caps, 0);
+  GST_DEBUG ("Caps features %p, contains overlay composition %d", f, gst_caps_features_contains (f, GST_CAPS_FEATURE_META_GST_VIDEO_OVERLAY_COMPOSITION));
 
   /* if the caps doesn't have the render meta, we query if downstream
    * accepts it before trying the version without the meta
@@ -362,6 +363,8 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
     gst_caps_features_add (f,
         GST_CAPS_FEATURE_META_GST_VIDEO_OVERLAY_COMPOSITION);
 
+    GST_DEBUG ("overlay_caps %" GST_PTR_FORMAT ", f %" GST_PTR_FORMAT, overlay_caps, f);
+
     ret = gst_pad_peer_query_accept_caps (render->srcpad, overlay_caps);
     GST_DEBUG_OBJECT (render, "Downstream accepts the render meta: %d", ret);
     if (ret) {
@@ -376,12 +379,13 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
   } else {
     original_has_meta = TRUE;
   }
-  GST_DEBUG_OBJECT (render, "Using caps %" GST_PTR_FORMAT, caps);
+  GST_DEBUG_OBJECT (render, ">>> Using caps %" GST_PTR_FORMAT ", original_has_meta %d, caps_has_meta %d", caps, original_has_meta, caps_has_meta);
   ret = gst_pad_set_caps (render->srcpad, caps);
 
   if (ret) {
     /* find supported meta */
     query = gst_query_new_allocation (caps, FALSE);
+    GST_DEBUG ("caps %" GST_PTR_FORMAT ", query %" GST_PTR_FORMAT, caps, query);
 
     if (!gst_pad_peer_query (render->srcpad, query)) {
       /* no problem, we use the query defaults */
@@ -395,6 +399,7 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
 
     gst_query_unref (query);
   }
+  GST_DEBUG ("ret %d, allocation_ret %d, attach %d", ret, allocation_ret, attach);
 
   if (!allocation_ret && render->video_flushing) {
     ret = FALSE;

--- a/gst/renderer/gstttmlrender.c
+++ b/gst/renderer/gstttmlrender.c
@@ -952,8 +952,10 @@ gst_ttml_render_video_event (GstPad * pad, GstObject * parent,
 
       gst_event_parse_caps (event, &caps);
       ret = gst_ttml_render_setcaps (render, caps);
-      if (render->width != prev_width || render->height != prev_height)
+      if (render->width != prev_width || render->height != prev_height) {
+        GST_DEBUG ("Render resolution changed from %d x %d to %d x %d", prev_width, prev_height, render->width, render->height);
         render->need_render = TRUE;
+      }
       gst_event_unref (event);
       break;
     }

--- a/gst/renderer/gstttmlrender.c
+++ b/gst/renderer/gstttmlrender.c
@@ -345,8 +345,9 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
   original_caps = caps;
 
   GstStructure const* const structure = gst_caps_get_structure (caps, 0);
-  gint overlay_composition_width, overlay_composition_height;
-  if (gst_structure_get_int (structure, "overlay-composition-width", &overlay_composition_width) && gst_structure_get_int (structure, "overlay-composition-height", &overlay_composition_height)) {
+  gint overlay_composition_width = 0, overlay_composition_height = 0;
+  if (gst_structure_get_int (structure, "overlay-composition-width", &overlay_composition_width) &&
+      gst_structure_get_int (structure, "overlay-composition-height", &overlay_composition_height)) {
     if (overlay_composition_width > 0 && overlay_composition_height > 0) {
       GST_DEBUG ("Applying downstream preference for overlay composition resolution %d x %d", overlay_composition_width, overlay_composition_height);
     }

--- a/gst/renderer/gstttmlrender.c
+++ b/gst/renderer/gstttmlrender.c
@@ -941,7 +941,7 @@ gst_ttml_render_video_event (GstPad * pad, GstObject * parent,
 
   render = GST_TTML_RENDER (parent);
 
-  GST_DEBUG_OBJECT (pad, "received event %s", GST_EVENT_TYPE_NAME (event));
+  GST_DEBUG_OBJECT (pad, "received event %" GST_PTR_FORMAT, event);
 
   switch (GST_EVENT_TYPE (event)) {
     case GST_EVENT_CAPS:

--- a/gst/renderer/gstttmlrender.c
+++ b/gst/renderer/gstttmlrender.c
@@ -348,13 +348,15 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
   if (gst_structure_get_int (structure, "overlay-composition-width", &overlay_composition_width) &&
       gst_structure_get_int (structure, "overlay-composition-height", &overlay_composition_height)) {
     if (overlay_composition_width > 0 && overlay_composition_height > 0) {
-      GST_DEBUG ("Applying downstream preference for overlay composition resolution %d x %d", overlay_composition_width, overlay_composition_height);
+      GST_DEBUG ("Applying downstream preference for overlay composition resolution %d x %d",
+        overlay_composition_width, overlay_composition_height);
     }
   }
 
   /* Try to use the render meta if possible */
   f = gst_caps_get_features (caps, 0);
-  GST_DEBUG ("Caps features %" GST_PTR_FORMAT ", contains overlay composition %d", f, gst_caps_features_contains (f, GST_CAPS_FEATURE_META_GST_VIDEO_OVERLAY_COMPOSITION));
+  GST_LOG ("Caps features %" GST_PTR_FORMAT ", contains overlay composition %d", f,
+    gst_caps_features_contains (f, GST_CAPS_FEATURE_META_GST_VIDEO_OVERLAY_COMPOSITION));
 
   /* if the caps doesn't have the render meta, we query if downstream
    * accepts it before trying the version without the meta
@@ -372,7 +374,7 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
     gst_caps_features_add (f,
         GST_CAPS_FEATURE_META_GST_VIDEO_OVERLAY_COMPOSITION);
 
-    GST_DEBUG ("overlay_caps %" GST_PTR_FORMAT ", f %" GST_PTR_FORMAT, overlay_caps, f);
+    GST_LOG ("overlay_caps %" GST_PTR_FORMAT ", f %" GST_PTR_FORMAT, overlay_caps, f);
 
     ret = gst_pad_peer_query_accept_caps (render->srcpad, overlay_caps);
     GST_DEBUG_OBJECT (render, "Downstream accepts the render meta: %d", ret);
@@ -394,7 +396,7 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
   if (ret) {
     /* find supported meta */
     query = gst_query_new_allocation (caps, FALSE);
-    GST_DEBUG ("caps %" GST_PTR_FORMAT ", query %" GST_PTR_FORMAT, caps, query);
+    GST_LOG ("caps %" GST_PTR_FORMAT ", query %" GST_PTR_FORMAT, caps, query);
 
     if (!gst_pad_peer_query (render->srcpad, query)) {
       /* no problem, we use the query defaults */
@@ -408,7 +410,7 @@ gst_ttml_render_negotiate (GstTtmlRender * render, GstCaps * caps)
 
     gst_query_unref (query);
   }
-  GST_DEBUG ("ret %d, allocation_ret %d, attach %d", ret, allocation_ret, attach);
+  GST_LOG ("ret %d, allocation_ret %d, attach %d", ret, allocation_ret, attach);
 
   if (!allocation_ret && render->video_flushing) {
     ret = FALSE;
@@ -2283,7 +2285,8 @@ gst_ttml_render_render_text_region (GstTtmlRender * render,
   GST_CAT_DEBUG (ttmlrender, "Height of rendered region: %u",
       region_image->height);
 
-  GST_INFO ("Overlay is %d x %d over video %d x %d", region_image->width, region_image->height, render->width, render->height);
+  GST_INFO ("Overlay is %d x %d over video %d x %d",
+    region_image->width, region_image->height, render->width, render->height);
 
   gst_ttml_render_compose_overlay (render, region_image);
   gst_ttml_render_rendered_image_free (region_image);

--- a/gst/renderer/gstttmlrender.h
+++ b/gst/renderer/gstttmlrender.h
@@ -107,7 +107,9 @@ struct _GstClTtmlRender {
 
     gboolean                 need_render;
 
-    gboolean                 attach_compo_to_buffer;
+    gboolean attach_compo_to_buffer; /* Deliver overlay composition (as opposed to inplace blending) */
+    gint overlay_composition_width;  /* fixed overlay composition resolution if requested downstream */
+    gint overlay_composition_height;
 
     GstVideoOverlayComposition *composition;
 };


### PR DESCRIPTION
This updates subtitle rendered to negotiate overlay composition reoslution with the downstream peers.

NOTE: 

- https://github.com/castlabs/gstreamer_asl/tree/CPD-91_KmsSandbox is the worker branch with https://github.com/castlabs/gstreamer_asl/tree/CPD-91_KmsSandbox/sandbox/gstplayer_kmssink_sandbox & embedded worker version of kmssink which can run on desktop Linux, Raspbian and the actual AERQ device
- https://git.aerq.com/embedded-sw/imx-gstreamer1.0-plugins-bad/-/merge_requests/8 sync'ed version of `kmssink` compatible with this PR